### PR TITLE
Use .zip for Windows artifacts

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,8 @@
+archive:
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
 build:
   binary: terraform-provider-dockermachine
   goos:


### PR DESCRIPTION
Unfortunately Windows doesn't come with anything to deal with `.tar.gz` and it's generally not reliable to expect 7zip or whatever archiver they might install as fresh installs, windows-based docker containers and windows build servers may not have it available. Safer to just provide a `.zip` for us poor folk :)